### PR TITLE
Add haptic feedback to filter buttons

### DIFF
--- a/packages/podcast_core/lib/screens/logged_in/podcast_details_screen.dart
+++ b/packages/podcast_core/lib/screens/logged_in/podcast_details_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:podcast_core/data/episode_with_status.dart';
@@ -108,6 +109,7 @@ class PodcastDetailsScreen
                           ),
                         ),
                         onPressed: () {
+                          HapticFeedback.lightImpact();
                           if (filterMenuController.isOpen) {
                             filterMenuController.close();
                           } else {

--- a/packages/podcast_core/lib/widgets/filter_episodes_popup.dart
+++ b/packages/podcast_core/lib/widgets/filter_episodes_popup.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:podcast_core/data/episodes_filter_state.dart';
 import 'package:podcast_core/extensions/text_style_extensions.dart';
@@ -34,7 +35,10 @@ class FilterEpisodesPopup extends ConsumerWidget {
               tooltip: 'Clear all filters',
               onPressed: filterState.isDefault
                   ? null
-                  : filterStateNotifier.clear,
+                  : () {
+                      HapticFeedback.lightImpact();
+                      filterStateNotifier.clear();
+                    },
             ),
           ),
           const Divider(),
@@ -44,6 +48,7 @@ class FilterEpisodesPopup extends ConsumerWidget {
             child: ListTile(
               title: const Text('Hide played episodes'),
               onTap: () {
+                HapticFeedback.lightImpact();
                 filterStateNotifier.setHideListened(
                   !filterState.hideListenedEpisodes,
                 );
@@ -100,7 +105,10 @@ class FilterEpisodesPopup extends ConsumerWidget {
                           ? 'Sort ascending'
                           : 'Sort descending',
                       child: InkResponse(
-                        onTap: filterStateNotifier.reverseSortOrder,
+                         onTap: () {
+                           HapticFeedback.lightImpact();
+                           filterStateNotifier.reverseSortOrder();
+                         },
                         child: Padding(
                           padding: const EdgeInsets.all(12),
                           child: PodcastAnimation(


### PR DESCRIPTION
This change adds haptic feedback to the following buttons:
- The button that opens the filter popup in the podcast details screen.
- The "Clear all filters" button in the filter popup.
- The "Hide played episodes" button in the filter popup.
- The "Reverse sort order" button in the filter popup.